### PR TITLE
fix(storage): Deployed, DeployedAll, and History methods should return correct errors.

### DIFF
--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -188,7 +188,7 @@ func TestStorageDeployed(t *testing.T) {
 
 	setup()
 
-	rls, err := storage.Last(name)
+	rls, err := storage.Deployed(name)
 	if err != nil {
 		t.Fatalf("Failed to query for deployed release: %s\n", err)
 	}
@@ -202,6 +202,17 @@ func TestStorageDeployed(t *testing.T) {
 		t.Fatalf("Expected release version %d, actual %d\n", vers, rls.Version)
 	case rls.Info.Status != rspb.StatusDeployed:
 		t.Fatalf("Expected release status 'DEPLOYED', actual %s\n", rls.Info.Status.String())
+	}
+}
+
+func TestStorageDeployedError(t *testing.T) {
+	storage := Init(driver.NewMemory())
+
+	const name = "angry-bird"
+
+	_, err := storage.Deployed(name)
+	if err != driver.ErrReleaseNotFound {
+		t.Fatalf("Expected ErrReleaseNotFound, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Local repo target for a hot sec, will retarget in a moment.

The `Deployed`, `DeployedAll`, and `History` methods all claim in their docstrings to return `ErrReleaseNotFound` when there are no matching releases, but their actual behavior is not correct:

1. `History` is dependent on the underlying implementation, which as #7372 points out below, is inconsistent between `ConfigMap` / `Secret` vs. `Memory`.
2. `Deployed` and `DeployedAll` return entirely custom errors.

This PR makes the `Storage` client consistent in behavior, regardless of the underlying `Driver` implementations:

1. All three methods now return `ErrReleaseNotFound` when `len(ls) == 0`. 
2. The test `TestStorageDeployed` in `storage_test.go` was calling `Last`, not `Deployed`. That's fixed.

I also added a tiny error test. I'd love to move these storage tests to table tests in a subsequent PR.

I searched and fond that this is adjacent to https://github.com/helm/helm/pull/7372, but gets at the problem at the client level, rather than the implementations. Both changes should be merged, in my opinion.

Signed-off-by: John Montroy john.montroy@walmart.com